### PR TITLE
Make LIO_SAM build when GTSAM is installed from PPA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ find_package(PCL REQUIRED QUIET)
 find_package(OpenCV REQUIRED QUIET)
 find_package(GTSAM REQUIRED QUIET)
 
+find_package(Boost REQUIRED COMPONENTS timer)
+
 add_message_files(
   DIRECTORY msg
   FILES


### PR DESCRIPTION
This makes sure that a required Boost component is found. GTSAM's cmake config that is installed with the PPA version already tries to find it, but searches specifically for version 1.43, which is older than what Ubuntu 18.04 has.

Depends on #2 to be merged/closed first.