### PR TITLE
Gps odom loop closure improvements

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -78,7 +78,7 @@ lio_sam:
   surroundingKeyframeSize: 50                   # submap size (when loop closure enabled)
   historyKeyframeSearchRadius: 15.0             # meters, key frame that is within n meters from current pose will be considerd for loop closure
   historyKeyframeSearchTimeDiff: 30.0           # seconds, key frame that is n seconds older will be considered for loop closure
-  historyKeyframeSearchNum: 25                  # number of hostory key frames will be fused into a submap for loop closure
+  historyKeyframeSearchNum: 500                  # number of hostory key frames will be fused into a submap for loop closure
   historyKeyframeFitnessScore: 0.3              # icp threshold, the smaller the better alignment
 
   # Visualization

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -4,7 +4,7 @@ lio_sam:
   pointCloudTopic: "points_raw"               # Point cloud data
   imuTopic: "/imu/data"                         # IMU data
   odomTopic: "odometry/imu"                   # IMU pre-preintegration odometry, same frequency as IMU
-  gpsTopic: "odometry/gpsz"                   # GPS odometry topic from navsat, see module_navsat.launch file
+  gpsTopic: "odometry/gps"                   # GPS odometry topic from navsat, see module_navsat.launch file
 
   # Frames
   lidarFrame: "velodyne"

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -27,7 +27,7 @@ lio_sam:
   N_SCAN: 32                                  # number of lidar channel (i.e., 16, 32, 64, 128)
   Horizon_SCAN: 1800                          # lidar horizontal resolution (Velodyne:1800, Ouster:512,1024,2048)
   downsampleRate: 1                           # default: 1. Downsample your data if too many points. i.e., 16 = 64 / 4, 16 = 16 / 1
-  lidarMinRange: 1.0                          # default: 1.0, minimum lidar range to be used
+  lidarMinRange: 3.0                          # default: 1.0, minimum lidar range to be used
   lidarMaxRange: 1000.0                       # default: 1000.0, maximum lidar range to be used
 
   # IMU Settings


### PR DESCRIPTION
These are the changes to LIO-SAM config I used to create the latest map
* Enabling GPS odometry helps greatly with ensuring that the path is still aligned after a big loop like around the Vantec building
* Increasing the number of keyframes for loop closure helps finding closures on the way back along the long bend and prevents misallignment and duplication
* Increasing the minimum range ensures that parts of the truck self aren't included in the map